### PR TITLE
Fix namespacing and allow image overload

### DIFF
--- a/roles/perceptilabs/defaults/main.yml
+++ b/roles/perceptilabs/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for perceptilabs
+frontend_image: "perceptilabs-frontend:latest"
+core_image: "perceptilabs-core:latest"

--- a/roles/perceptilabs/templates/core.yaml.j2
+++ b/roles/perceptilabs/templates/core.yaml.j2
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: perceptilabs-core
+  namespace: {{ meta.namespace }}
   labels: &default-labels
     app.kubernetes.io/name: perceptilabs-core
     app.kubernetes.io/version: v1.0.0-v1alpha1
@@ -18,7 +19,7 @@ spec:
     spec:
       containers:
       - name: core
-        image: perceptilabs-core:latest
+        image: "{{ core_image }}"
         imagePullPolicy: IfNotPresent
         # env:
         # - name: FOO
@@ -28,6 +29,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: perceptilabs-core
+  namespace: {{ meta.namespace }}
 spec:
   selector:
     app.kubernetes.io/name: perceptilabs-core

--- a/roles/perceptilabs/templates/frontend.yaml.j2
+++ b/roles/perceptilabs/templates/frontend.yaml.j2
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: perceptilabs-frontend
+  namespace: {{ meta.namespace }}
   labels: &default-labels
     app.kubernetes.io/name: perceptilabs-frontend
     app.kubernetes.io/version: v1.0.0-v1alpha1
@@ -17,13 +18,14 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: perceptilabs-frontend:latest
+        image: "{{ frontend_image }}"
         imagePullPolicy: IfNotPresent
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: perceptilabs-frontend
+  namespace: {{ meta.namespace }}
 spec:
   selector:
     app.kubernetes.io/name: perceptilabs-frontend
@@ -37,6 +39,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: perceptilabs-frontend
+  namespace: {{ meta.namespace }}
 spec:
   to:
     kind: Service


### PR DESCRIPTION
This change uses meta.namespace in all of the objects so that
ansible can get the namespace from the CR. It also allows
the core and frontend images to be overridden from the CR,
but defaults them to "perceptilabs-xxxx:latest"