### PR TITLE
Add gpu count and persistent volume claim to custom resource

### DIFF
--- a/deploy/crds/perceptilabs_v1alpha1_perceptilabs_cr.yaml
+++ b/deploy/crds/perceptilabs_v1alpha1_perceptilabs_cr.yaml
@@ -4,4 +4,7 @@ metadata:
   name: example-perceptilabs
 spec:
   # Add fields here
-  size: 3
+  # frontendImage: quay.io/tmckayus/perceptilabs-frontend:v5
+  # coreImage: quay.io/tmckayus/perceptilabs-core:v5
+  # coreGpus: 3
+  # corePvc: mydata

--- a/roles/perceptilabs/templates/core.yaml.j2
+++ b/roles/perceptilabs/templates/core.yaml.j2
@@ -21,9 +21,20 @@ spec:
       - name: core
         image: "{{ core_image }}"
         imagePullPolicy: IfNotPresent
-        # env:
-        # - name: FOO
-        #   value: "bar"
+{% if core_gpus %}
+        resources:
+          limits:
+            nvidia.com/gpu: "{{ core_gpus }}"
+{% endif %}
+{% if core_pvc %}
+        volumeMounts:
+        - mountPath: /mnt/plabs
+          name: core-data-volume
+      volumes:
+      - name: core-data-volume
+        persistentVolumeClaim:
+          claimName: "{{ core_pvc }}"
+{% endif %}
 ---
 apiVersion: v1
 kind: Service

--- a/roles/perceptilabs/vars/main.yml
+++ b/roles/perceptilabs/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for perceptilabs
+core_gpus: null
+core_pvc: null


### PR DESCRIPTION
This change allows the following to be set in a perceptilabs CR

* coreGpus: gpus to be requested by the core container, no gpus are requested if this value is absent
* corePvc: the name of a persistent volume claim to mount on the core contaienr at /mnt/plabs, no volume is mounted if the value is absent